### PR TITLE
feat: Implement initial scaffolding for resume builder UI

### DIFF
--- a/app/builder/[id]/page.tsx
+++ b/app/builder/[id]/page.tsx
@@ -1,0 +1,18 @@
+"use client"; // Needed if you directly use client hooks here, or for event handlers.
+               // ResumeBuilder itself might be a client component.
+import React from 'react';
+import AppLayout from '../../../../components/layout/AppLayout'; // Adjust path
+import ResumeBuilder from '../../../../components/resume/ResumeBuilder'; // Adjust path
+// It's good practice to ensure user is authenticated here as well,
+// or rely on a higher-level protection mechanism if dashboard is the only entry.
+// For now, we'll focus on the structure.
+
+export default function BuilderPage({ params }: { params: { id: string } }) {
+  const { id } = params;
+
+  return (
+    <AppLayout>
+      <ResumeBuilder resumeId={id} />
+    </AppLayout>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+import { supabase } from "../../lib/supabaseClient"; // Adjusted path
+import type { User } from "@supabase/supabase-js";
+import { useEffect, useState } from "react";
+import { useRouter } from 'next/navigation'; // Import useRouter
+import AppLayout from '../../components/layout/AppLayout'; // Import AppLayout
+import ResumeList from '../../components/dashboard/ResumeList'; // Import ResumeList
+
+// Define Resume type, or import from a shared location if available
+interface Resume {
+  id: string;
+  title: string;
+  created_at?: string;
+}
+
+export default function DashboardPage() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [resumes, setResumes] = useState<Resume[]>([]); // Use Resume type
+  const [resumeTitle, setResumeTitle] = useState("");
+  const [resumesLoading, setResumesLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const getUser = async () => {
+      const { data, error: authError } = await supabase.auth.getUser();
+      if (authError || !data?.user) {
+        router.push('/');
+        return;
+      }
+      setUser(data.user);
+      setLoading(false);
+    };
+    getUser();
+  }, [router]);
+
+  useEffect(() => {
+    if (user) {
+      fetchResumes();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
+
+  const fetchResumes = async () => {
+    setResumesLoading(true);
+    setError(null);
+    const { data, error } = await supabase
+      .from("resumes")
+      .select("id, title, created_at")
+      .order("created_at", { ascending: false });
+    if (error) setError(error.message);
+    setResumes((data as Resume[]) || []); // Cast to Resume[]
+    setResumesLoading(false);
+  };
+
+  const handleAddResume = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!resumeTitle.trim() || !user) return;
+    const { error } = await supabase
+      .from("resumes")
+      .insert([{ title: resumeTitle.trim(), user_id: user.id }]);
+    if (error) setError(error.message);
+    setResumeTitle("");
+    fetchResumes();
+  };
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+    setUser(null);
+    router.push('/');
+  };
+
+  if (loading) {
+    return <div className="flex items-center justify-center min-h-screen">Loading...</div>;
+  }
+
+  if (!user) {
+    return <div className="flex items-center justify-center min-h-screen">Redirecting to login...</div>;
+  }
+
+  return (
+    <AppLayout>
+      <div className="flex flex-col items-center justify-center min-h-screen gap-6 w-full max-w-xl mx-auto">
+        <h1 className="text-2xl font-bold">Welcome, {user?.email}</h1>
+        <button
+          className="px-6 py-3 rounded bg-gray-200 hover:bg-gray-300 shadow"
+          onClick={handleSignOut}
+        >
+          Sign out
+        </button>
+
+        <div className="w-full mt-6">
+          <h2 className="text-xl font-semibold mb-2">Your Resumes</h2>
+          <form className="flex gap-2 mb-4" onSubmit={handleAddResume}>
+            <input
+              className="flex-1 px-3 py-2 border rounded shadow"
+              type="text"
+              placeholder="Resume title"
+              value={resumeTitle}
+              onChange={e => setResumeTitle(e.target.value)}
+            />
+            <button
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              type="submit"
+            >
+              Add
+            </button>
+          </form>
+          <ResumeList resumes={resumes} loading={resumesLoading} error={error} />
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,13 @@
 "use client";
-"use client";
 import { supabase } from "../lib/supabaseClient";
 import type { User } from "@supabase/supabase-js";
 import { useEffect, useState } from "react";
+import { useRouter } from 'next/navigation';
 
-export default function Home() {
+export default function AuthPage() { // Renamed function to AuthPage
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
-  const [resumes, setResumes] = useState<any[]>([]);
-  const [resumeTitle, setResumeTitle] = useState("");
-  const [resumesLoading, setResumesLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const getUser = async () => {
@@ -22,42 +19,13 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    if (user) fetchResumes();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user]);
-
-  const fetchResumes = async () => {
-    setResumesLoading(true);
-    setError(null);
-    const { data, error } = await supabase
-      .from("resumes")
-      .select("id, title, created_at")
-      .order("created_at", { ascending: false });
-    if (error) setError(error.message);
-    setResumes(data || []);
-    setResumesLoading(false);
-  };
-
-  const handleAddResume = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-    if (!resumeTitle.trim()) return;
-    const { error } = await supabase
-      .from("resumes")
-      .insert([{ title: resumeTitle.trim(), user_id: user?.id }]);
-    if (error) setError(error.message);
-    setResumeTitle("");
-    fetchResumes();
-  };
-
+    if (user) {
+      router.push('/dashboard');
+    }
+  }, [user, router]);
 
   const handleSignIn = async () => {
     await supabase.auth.signInWithOAuth({ provider: "google" });
-  };
-
-  const handleSignOut = async () => {
-    await supabase.auth.signOut();
-    setUser(null);
   };
 
   if (loading) {
@@ -78,47 +46,6 @@ export default function Home() {
     );
   }
 
-  return (
-    <div className="flex flex-col items-center justify-center min-h-screen gap-6 w-full max-w-xl mx-auto">
-      <h1 className="text-2xl font-bold">Welcome, {user?.email}</h1>
-      <button
-        className="px-6 py-3 rounded bg-gray-200 hover:bg-gray-300 shadow"
-        onClick={handleSignOut}
-      >
-        Sign out
-      </button>
-
-      <div className="w-full mt-6">
-        <h2 className="text-xl font-semibold mb-2">Your Resumes</h2>
-        <form className="flex gap-2 mb-4" onSubmit={handleAddResume}>
-          <input
-            className="flex-1 px-3 py-2 border rounded shadow"
-            type="text"
-            placeholder="Resume title"
-            value={resumeTitle}
-            onChange={e => setResumeTitle(e.target.value)}
-          />
-          <button
-            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-            type="submit"
-          >
-            Add
-          </button>
-        </form>
-        {resumesLoading ? (
-          <div>Loading resumes...</div>
-        ) : error ? (
-          <div className="text-red-600">{error}</div>
-        ) : resumes.length === 0 ? (
-          <div>No resumes yet. Add your first one!</div>
-        ) : (
-          <ul className="w-full">
-            {resumes.map(r => (
-              <li key={r.id} className="border-b py-2">{r.title}</li>
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
-  );
+  // If user exists, redirect is handled by useEffect. Can show a loading/redirecting message.
+  return <div className="flex items-center justify-center min-h-screen">Redirecting to dashboard...</div>;
 }

--- a/components/dashboard/.gitkeep
+++ b/components/dashboard/.gitkeep
@@ -1,0 +1,1 @@
+# This file is used to ensure the directory is tracked by git.

--- a/components/dashboard/ResumeCard.tsx
+++ b/components/dashboard/ResumeCard.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Link from 'next/link'; // Import Link
+
+interface Resume { // Consider defining this in a shared types file later
+  id: string;
+  title: string;
+  // created_at?: string; // Optional, if you want to display it
+}
+
+interface ResumeCardProps {
+  resume: Resume;
+}
+
+const ResumeCard: React.FC<ResumeCardProps> = ({ resume }) => {
+  return (
+    <li className="border-b py-3 px-4 mb-2 bg-white shadow rounded hover:bg-gray-50 flex justify-between items-center">
+      <div>
+        <h3 className="text-lg font-semibold">{resume.title}</h3>
+        {/* Optional: Display other info like last edited date here */}
+      </div>
+      <Link href={`/builder/${resume.id}`} legacyBehavior>
+        <a className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm">
+          Open Builder
+        </a>
+      </Link>
+      {/* Placeholder for future actions (e.g., delete button) can go here or next to the title */}
+    </li>
+  );
+};
+
+export default ResumeCard;

--- a/components/dashboard/ResumeList.tsx
+++ b/components/dashboard/ResumeList.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import ResumeCard from './ResumeCard'; // Assuming it's in the same directory
+
+interface Resume { // Duplicate or move to a shared types file
+  id: string;
+  title: string;
+  created_at?: string;
+}
+
+interface ResumeListProps {
+  resumes: Resume[];
+  loading: boolean;
+  error: string | null;
+}
+
+const ResumeList: React.FC<ResumeListProps> = ({ resumes, loading, error }) => {
+  if (loading) {
+    return <div className="text-center py-4">Loading resumes...</div>;
+  }
+
+  if (error) {
+    return <div className="text-red-600 bg-red-100 p-3 rounded">{error}</div>;
+  }
+
+  if (resumes.length === 0) {
+    return <div className="text-center py-4 text-gray-600">No resumes yet. Add your first one!</div>;
+  }
+
+  return (
+    <ul className="space-y-4">
+      {resumes.map(resume => (
+        <ResumeCard key={resume.id} resume={resume} />
+      ))}
+    </ul>
+  );
+};
+
+export default ResumeList;

--- a/components/layout/.gitkeep
+++ b/components/layout/.gitkeep
@@ -1,0 +1,1 @@
+# This file is used to ensure the directory is tracked by git.

--- a/components/layout/AppLayout.tsx
+++ b/components/layout/AppLayout.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface AppLayoutProps {
+  children: React.ReactNode;
+}
+
+const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
+  return (
+    <div className="min-h-screen bg-gray-100"> {/* Optional: basic background color */}
+      {/* <header>Header placeholder</header> */} {/* Optional: placeholder for future header */}
+      <main className="container mx-auto p-4"> {/* Basic container and padding */}
+        {children}
+      </main>
+      {/* <footer>Footer placeholder</footer> */} {/* Optional: placeholder for future footer */}
+    </div>
+  );
+};
+
+export default AppLayout;

--- a/components/resume/.gitkeep
+++ b/components/resume/.gitkeep
@@ -1,0 +1,1 @@
+# This file is used to ensure the directory is tracked by git.

--- a/components/resume/ResumeBuilder.tsx
+++ b/components/resume/ResumeBuilder.tsx
@@ -1,0 +1,24 @@
+"use client"; 
+import React from 'react';
+import TemplatePicker from './TemplatePicker'; // Import TemplatePicker
+
+interface ResumeBuilderProps {
+  resumeId: string;
+}
+
+const ResumeBuilder: React.FC<ResumeBuilderProps> = ({ resumeId }) => {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Resume Builder</h1>
+      <p>Currently building resume with ID: <strong>{resumeId}</strong></p>
+      
+      <TemplatePicker /> {/* Integrate TemplatePicker here */}
+
+      <p className="mt-6 text-gray-600">
+        Section editing and AI suggestions are coming soon!
+      </p>
+    </div>
+  );
+};
+
+export default ResumeBuilder;

--- a/components/resume/TemplatePicker.tsx
+++ b/components/resume/TemplatePicker.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const TemplatePicker: React.FC = () => {
+  return (
+    <div className="my-6 p-4 border border-dashed border-gray-300 rounded">
+      <h2 className="text-xl font-semibold mb-2">Choose a Template</h2>
+      <p className="text-gray-500">
+        Template selection will be available here soon.
+        For now, a default template will be used.
+      </p>
+      {/* Placeholder for template thumbnails or options */}
+    </div>
+  );
+};
+
+export default TemplatePicker;


### PR DESCRIPTION
This commit introduces the foundational structure for the AI resume builder.

Key changes include:

- Refactored the main page:
    - `app/page.tsx` now primarily handles authentication.
    - `app/dashboard/page.tsx` is the new home for your dashboard, displaying your resumes.
- Established a component-based architecture:
    - Created `components` directory with `layout`, `dashboard`, and `resume` subdirectories.
    - Implemented `AppLayout` for consistent page structure.
    - Developed `ResumeList` and `ResumeCard` components to display resumes on the dashboard.
- Added placeholder pages and components for the resume builder:
    - Created `app/builder/[id]/page.tsx` as the dynamic route for editing individual resumes.
    - Implemented `ResumeBuilder.tsx` as the main component for this page.
    - Added a `TemplatePicker.tsx` placeholder component within the resume builder.
- Implemented navigation:
    - You can now navigate from a resume card on the dashboard to its corresponding builder page.

This scaffolding sets the stage for future development of template selection, section editing, and AI-powered content generation.